### PR TITLE
Remove incorrect charset override

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -11,7 +11,6 @@ export default defineNuxtConfig({
   css: ["kiso.css", "~/assets/css/fonts.css", "~/assets/css/view-transitions.css"],
   app: {
     head: {
-      charset: 'utf-16',
       viewport: 'width=device-width',
       link: [
         { rel: "canonical", href: "https://mq1.dev/" },


### PR DESCRIPTION
身内の Slack で記事を紹介された際、リンクプレビューのタイトルや description が文字化けしていました。

該当ページの生成 HTML を確認すると、実体は UTF-8 として読める一方で、`<meta charset="utf-16">` が出力されており、不整合が生じているようです。

本 PR では `app.head.charset` の明示指定の削除を提案します。

microCMS からは JSON でコンテンツを受け取っているようなので、UTF-8 前提で扱ってよいはずです。
また、Nuxt 側では `app.head.charset` 指定がなければ UTF-8 がデフォルトのようですので、明示設定は不要かと思います。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * アプリケーション設定から charset 設定を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->