### PR TITLE
chore: Automatic trailing slashes の無効化

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -15,7 +15,8 @@
 		}
 	],
 	"assets": {
-		"directory": ".output/public"
+		"directory": ".output/public",
+		"html_handling": "drop-trailing-slash"
 	},
 	"observability": {
 		"enabled": true


### PR DESCRIPTION
コード内で `<NuxtLink :to="...">` などが末尾 slash 無し (`https://mq1.dev/entry/:entryname` のような) に対して遷移し, URL コピー機能も末尾 slash 無しの URL を提供しますが, [Cloudflare の HTML handling 機能は既定でこれらに対して 307 を返します](https://developers.cloudflare.com/workers/static-assets/routing/advanced/html-handling/#automatic-trailing-slashes-default). 実用上問題はありませんが, SPA の挙動と Workers 側の挙動を揃えた方が better だと思います.

もし末尾 slash を正規化 (有り / 無し) する意図があった場合, `.assets.html_handling` はその挙動に合わせると良いでしょう. [pathname に関わるこれらの機能を単に無効化することもできます](https://developers.cloudflare.com/workers/static-assets/routing/advanced/html-handling/#disable-html-handling).

参照: [HTML handling · Cloudflare Workers docs](https://developers.cloudflare.com/workers/static-assets/routing/advanced/html-handling/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* **URL処理の設定を更新しました。** HTMLファイルへのアクセス時にURLの末尾のスラッシュを自動的に削除する設定を追加しました。これにより、URLの標準化とアクセス性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->